### PR TITLE
Usage example apt for both browser and node.js

### DIFF
--- a/packages/cli/src/codegen/generators/ts_generator.ts
+++ b/packages/cli/src/codegen/generators/ts_generator.ts
@@ -119,11 +119,12 @@ export function generate(
     logDetail(`
 \`\`\`
 import Syft, { AmplitudePlugin } from '@syftdata/client'
+...
 const syft = new Syft({
-   appVersion: "1.0.0",
-    plugins: [new AmplitudePlugin()]
+  appVersion: "1.0.0",
+  plugins: [new AmplitudePlugin(amplitude)]
 })
-syft.pageEvent({name: 'index'});
+syft.pageViewed({name: 'index'});
 \`\`\``);
   } else {
     logVerbose('Skipping js generation to keep unit-tests faster');


### PR DESCRIPTION
### Based on feedback from Will!
- We generate PageViewed event by default
- We should show example with passing an amplitude instance. which would work for both browser and node.