### PR TITLE
Support GA4

### DIFF
--- a/packages/client/src/plugins/GA4.ts
+++ b/packages/client/src/plugins/GA4.ts
@@ -13,9 +13,6 @@ declare global {
   }
 }
 
-/**
- * Plugin added to Syft.
- */
 export class GA4Plugin implements ISyftPlugin {
   id = 'GA4';
   syft: Syft;
@@ -43,13 +40,13 @@ export class GA4Plugin implements ISyftPlugin {
   }
 
   logEvent(event: SyftEvent): boolean {
-    if (this.isBrowser) {
-      this.gtag = window.gtag;
+    if (!this.isBrowser) {
+      return true;
     }
+    this.gtag = window.gtag;
 
     const { syft, ...props } = event;
     const fullProps: Record<string, any> = { ...props, via_syft: true };
-    console.log('GA4 logEvent', syft.eventType, syft.eventName, fullProps);
     if (syft.eventType === SyftEventType.TRACK) {
       this.gtag('event', syft.eventName, fullProps);
     } else if (syft.eventType === SyftEventType.PAGE) {

--- a/packages/client/src/plugins/GA4.ts
+++ b/packages/client/src/plugins/GA4.ts
@@ -1,0 +1,98 @@
+import type Syft from '../generated';
+import {
+  type IReflector,
+  SyftEventType,
+  type SyftEvent,
+  type ISyftPlugin
+} from '../types';
+
+declare global {
+  interface Window {
+    gtag: any;
+    dataLayer: any;
+  }
+}
+
+/**
+ * Plugin added to Syft.
+ */
+export class GA4Plugin implements ISyftPlugin {
+  id = 'GA4';
+  syft: Syft;
+  gtag: any;
+  isBrowser = typeof window !== 'undefined';
+
+  constructor() {
+    if (!this.isBrowser) {
+      console.error('GA4 plugin is only supported in browser');
+    }
+  }
+
+  load(): void {
+    if (this.isBrowser) {
+      if (window.gtag == null) {
+        console.error('Please install/initalize GA4 SDK!');
+      }
+    }
+  }
+
+  init(reflector: IReflector): void {}
+
+  isLoaded(): boolean {
+    return true;
+  }
+
+  logEvent(event: SyftEvent): boolean {
+    if (this.isBrowser) {
+      this.gtag = window.gtag;
+    }
+
+    const { syft, ...props } = event;
+    const fullProps: Record<string, any> = { ...props, via_syft: true };
+    console.log('GA4 logEvent', syft.eventType, syft.eventName, fullProps);
+    if (syft.eventType === SyftEventType.TRACK) {
+      this.gtag('event', syft.eventName, fullProps);
+    } else if (syft.eventType === SyftEventType.PAGE) {
+      this.gtag('event', 'page_view', {
+        page_location: fullProps.url,
+        page_referrer: fullProps.referrer,
+        page_title: fullProps.title ?? fullProps.name ?? syft.eventName,
+        ...fullProps
+      });
+    } else if (syft.eventType === SyftEventType.SCREEN) {
+      if (fullProps.name == null) {
+        fullProps.name = syft.eventName;
+      }
+      this.gtag('event', 'screen_view', fullProps);
+    } else if (syft.eventType === SyftEventType.IDENTIFY) {
+      const { userId, ...subProps } = fullProps;
+      if (userId != null) {
+        this.gtag('set', 'user_properties', {
+          user_id: userId,
+          ...subProps
+        });
+      } else {
+        console.warn('User Identify event doesnt have userId');
+      }
+    } else if (syft.eventType === SyftEventType.GROUP_IDENTIFY) {
+      const { groupId, ...subProps } = fullProps;
+      if (groupId != null) {
+        this.gtag('event', 'join_group', {
+          group_id: groupId,
+          ...subProps
+        });
+      } else {
+        console.warn('Group Identify event doesnt have groupId');
+      }
+    }
+    return true;
+  }
+
+  resetUserProperties(): void {
+    if (this.gtag != null) {
+      this.gtag.reset();
+    }
+  }
+}
+
+export default GA4Plugin;

--- a/packages/client/src/plugins/index.ts
+++ b/packages/client/src/plugins/index.ts
@@ -2,4 +2,5 @@ export * from './Segment';
 export * from './Amplitude';
 export * from './MixPanel';
 export * from './Heap';
+export * from './GA4';
 export * from './TestingPlugin';


### PR DESCRIPTION
This PR adds a plugin for Google Analytics 4. 

It logs Track events by their name. GroupIdentify events as "join_group", Page events as "page_view", Screen events as "screen_view"

Tested in an example app and verified that the events are showing up properly.

Note: This plugin works only in the browser and doesn't work on Node. 