### PR TITLE
Run a script post Install to generate code.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11933,7 +11933,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@es-joy/jsdoccomment": "^0.37.0",
-        "@syftdata/client": "^0.1.4",
         "@typescript-eslint/eslint-plugin": "^5.51.0",
         "@typescript-eslint/parser": "^5.51.0",
         "chalk": "^4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12256,6 +12256,7 @@
     "packages/client": {
       "name": "@syftdata/client",
       "version": "0.1.4",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.20.5"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -67,7 +67,6 @@
   },
   "dependencies": {
     "@es-joy/jsdoccomment": "^0.37.0",
-    "@syftdata/client": "^0.1.4",
     "@typescript-eslint/eslint-plugin": "^5.51.0",
     "@typescript-eslint/parser": "^5.51.0",
     "chalk": "^4.1",

--- a/packages/cli/src/client_types.ts
+++ b/packages/cli/src/client_types.ts
@@ -1,0 +1,30 @@
+// TODO this file is a duplicate of packages/client/src/types.ts
+// Move it into its own core package and share.
+
+export enum SyftEventType {
+  TRACK,
+  PAGE,
+  SCREEN,
+  IDENTIFY,
+  GROUP_IDENTIFY
+}
+
+export enum NamingCase {
+  KEEP_AS_IS,
+  SNAKE, // Replace spaces with underscore and lowercase.
+  CAMEL, // Remove spaces/underscores and convert first letter to uppercase.
+  PASCAL,
+  TITLE,
+  LOWER,
+  UPPER
+}
+
+// config provided during code generation
+export interface StaticConfig {
+  projectName: string;
+  version: string;
+  strict?: boolean; // drops events if they fail invalid checks.
+  eventNameCase?: NamingCase;
+  propertyNameCase?: NamingCase;
+  lintingDisabled?: boolean;
+}

--- a/packages/cli/src/codegen/generators/dbt_generator.ts
+++ b/packages/cli/src/codegen/generators/dbt_generator.ts
@@ -11,7 +11,7 @@ import {
   type BigQueryConfig,
   type ProviderConfig
 } from '../../config/sink_configs';
-import { SyftEventType } from '@syftdata/client';
+import { SyftEventType } from '../../client_types';
 
 // HACK: ignore user identity and index too. they don't exist in BQ yet.
 const EXCLUDED = ['UserIdentity', 'Index', 'TrackedEvent', 'PageEvent'];

--- a/packages/cli/src/codegen/generators/model_generator.ts
+++ b/packages/cli/src/codegen/generators/model_generator.ts
@@ -8,7 +8,7 @@ import { type AST } from '../types';
 import * as path from 'path';
 import * as handlebars from 'handlebars';
 import { EVENT_MODELS_TEMPLATE } from '../templates/model_template';
-import { SyftEventType } from '@syftdata/client';
+import { SyftEventType } from '../../client_types';
 
 // TODO: Memoize
 function getEventModelsTemplate(): HandlebarsTemplateDelegate<any> {

--- a/packages/cli/src/codegen/generators/ts_generator.ts
+++ b/packages/cli/src/codegen/generators/ts_generator.ts
@@ -8,7 +8,7 @@ import {
   logVerbose,
   lowerize
 } from '../../utils';
-import { SyftEventType } from '@syftdata/client';
+import { SyftEventType } from '../../client_types';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as handlebars from 'handlebars';

--- a/packages/cli/src/codegen/types.ts
+++ b/packages/cli/src/codegen/types.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
-import { type StaticConfig, type SyftEventType } from '@syftdata/client';
+import { type StaticConfig, type SyftEventType } from '../client_types';
 import { type Expression } from 'ts-morph';
 
 interface BasicInfo {

--- a/packages/cli/src/codegen/visitor.ts
+++ b/packages/cli/src/codegen/visitor.ts
@@ -1,5 +1,5 @@
 import { type EventSchema, type Field, type TypeField } from './types';
-import { SyftEventType } from '@syftdata/client';
+import { SyftEventType } from '../client_types';
 import {
   JSDocTypeTag,
   type ClassDeclaration,

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -1,4 +1,4 @@
-import type { StaticConfig } from '@syftdata/client';
+import type { StaticConfig } from '../client_types';
 import type { ObjectLiteralExpression, Project } from 'ts-morph';
 import { SyntaxKind, PropertyAssignment } from 'ts-morph';
 import { createTSProject } from '../codegen/compiler';

--- a/packages/cli/src/init/destination.ts
+++ b/packages/cli/src/init/destination.ts
@@ -1,7 +1,7 @@
 import * as http from 'http';
 import * as https from 'https';
 import type { AST, EventSchema, Field } from '../codegen/types';
-import { SyftEventType } from '@syftdata/client';
+import { SyftEventType } from '../client_types';
 import { CLIVersion } from '../config/pkg';
 import { logVerbose } from '../utils';
 

--- a/packages/cli/src/init/local.ts
+++ b/packages/cli/src/init/local.ts
@@ -2,7 +2,7 @@ import { type AST, type EventSchema, type Field } from '../codegen/types';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as glob from 'glob';
-import { SyftEventType } from '@syftdata/client';
+import { SyftEventType } from '../client_types';
 import { capitalize, logVerbose } from '../utils';
 
 function getEventSchemasFromFolder(folder: string): EventSchema[] {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -39,11 +39,12 @@
   },
   "scripts": {
     "prebuild": "rm -rf ./lib",
-    "build": "tsc",
+    "build": "tsc && tsc --project tsconfig_scripts.json",
     "build-bundle": "npx webpack --config webpack.config.js",
     "test": "jest",
     "lint": "eslint --ext .ts src tests --fix",
     "prepublish": "npm run build",
+    "postinstall": "node ./lib/scripts/postinstall.js",
     "prettier-format": "prettier --config .prettierrc 'src/**/*.ts' --write"
   },
   "devDependencies": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -44,7 +44,7 @@
     "test": "jest",
     "lint": "eslint --ext .ts src tests --fix",
     "prepublish": "npm run build",
-    "postinstall": "node ./lib/scripts/postinstall.js",
+    "postinstall": "node ./lib/scripts/postinstall.js || true",
     "prettier-format": "prettier --config .prettierrc 'src/**/*.ts' --write"
   },
   "devDependencies": {

--- a/packages/client/scripts/postinstall.ts
+++ b/packages/client/scripts/postinstall.ts
@@ -1,0 +1,107 @@
+import * as path from 'path';
+import * as fs from 'fs';
+import * as childProcess from 'child_process';
+
+async function run(
+  cmd: string,
+  params: string[],
+  cwd = process.cwd()
+): Promise<void> {
+  const child = childProcess.spawn(cmd, params, {
+    stdio: ['pipe', 'inherit', 'inherit'],
+    cwd
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    child.on('close', () => {
+      resolve();
+    });
+    child.on('exit', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(code);
+      }
+    });
+    child.on('error', () => {
+      reject(new Error('unknown process error'));
+    });
+  });
+}
+
+function copyRecursiveSync(src: string, dest: string): void {
+  const exists = fs.existsSync(src);
+  const stats = exists ? fs.statSync(src) : null;
+  const isDirectory = stats?.isDirectory();
+  if (isDirectory === true) {
+    fs.mkdirSync(dest);
+    fs.readdirSync(src).forEach(function (childItemName) {
+      copyRecursiveSync(
+        path.join(src, childItemName),
+        path.join(dest, childItemName)
+      );
+    });
+  } else {
+    fs.copyFileSync(src, dest);
+  }
+}
+
+/**
+ * Copy the lib into .syft/client folder and generate files in .syft/client.
+ * This is required for two reasons:
+ * 1. Keep the library fail safe. Our library loads files from .syft/client only.
+ * 2. Package managers like pnpm maintain symboling links to the packages.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+async function copyGeneratedFiles(): Promise<void> {
+  try {
+    const dotSyftClientDir = path.join(__dirname, '../../../../.syft/client');
+    fs.mkdirSync(dotSyftClientDir, { recursive: true });
+    copyRecursiveSync(path.join(__dirname, '..'), dotSyftClientDir);
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+function getLocalPackagePath(pkg: string): string | null {
+  try {
+    const packagePath = require.resolve(`${pkg}/package.json`);
+    if (packagePath != null) {
+      return require.resolve(pkg);
+    }
+  } catch (e) {} // eslint-disable-line no-empty
+  return null;
+}
+
+async function main(): Promise<void> {
+  if (process.env.INIT_CWD != null) {
+    process.chdir(process.env.INIT_CWD); // necessary, because npm chooses __dirname as process.cwd()
+    // in the postinstall hook
+  }
+
+  // await copyGeneratedFiles();
+  const localPath = getLocalPackagePath('@syftdata/cli');
+  try {
+    if (localPath != null) {
+      await run('node', [localPath, 'generate', 'ts']);
+    } else {
+      console.error("Couldn't find Syft CLI.");
+    }
+  } catch (e) {
+    // if exit code = 1 do not print
+    if (e !== 1) {
+      console.error(e);
+    }
+  }
+}
+
+if (process.env.SYFT_SKIP_POSTINSTALL_GENERATE == null) {
+  main().catch((e) => {
+    if (e.stderr != null) {
+      console.error(e.stderr);
+    } else {
+      console.error(e);
+    }
+    process.exit(0);
+  });
+}

--- a/packages/client/scripts/postinstall.ts
+++ b/packages/client/scripts/postinstall.ts
@@ -80,8 +80,8 @@ async function main(): Promise<void> {
   }
 
   // await copyGeneratedFiles();
-  const localPath = getLocalPackagePath('@syftdata/cli');
   try {
+    const localPath = getLocalPackagePath('@syftdata/cli');
     if (localPath != null) {
       await run('node', [localPath, 'generate', 'ts']);
     } else {

--- a/packages/client/tsconfig_scripts.json
+++ b/packages/client/tsconfig_scripts.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./lib/scripts",
+    "lib": ["ES2015"]
+  },
+  "include": [
+    "./scripts"
+  ]
+}

--- a/scripts/test_local.sh
+++ b/scripts/test_local.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+npx lerna run build
+cd packages/client
+npm pack
+cd ../cli
+npm pack
+cd ../../


### PR DESCRIPTION
This change is to run post-install script for @syftdata/client. It runs every time it is installed. 

This is helpful for:
1. We don't have to run the command when we upgrade the package.
2. We don't need to run a special command during deployment. 
