### PR TITLE
Make Syft work on React native.

### DIFF
--- a/packages/cli/src/codegen/generators/ts_generator.ts
+++ b/packages/cli/src/codegen/generators/ts_generator.ts
@@ -81,7 +81,7 @@ export function generate(
       target: ScriptTarget.ES2015,
       declaration: true,
       declarationMap: true,
-      sourceMap: true,
+      sourceMap: false,
       strictNullChecks: true,
       module: ModuleKind.CommonJS,
       noImplicitAny: false,

--- a/packages/client/src/batcher.ts
+++ b/packages/client/src/batcher.ts
@@ -18,9 +18,11 @@ import { convertCase } from './utils';
 import { PluginLoader } from './PluginLoader';
 
 /* eslint-disable @typescript-eslint/no-var-requires */
-let EnvClasses = require('./node');
+let EnvClasses;
 if (typeof window !== 'undefined') {
   EnvClasses = require('./browser');
+} else {
+  EnvClasses = require('./node');
 }
 
 export default class Batcher {

--- a/packages/client/src/node/uploader.ts
+++ b/packages/client/src/node/uploader.ts
@@ -1,42 +1,43 @@
 import type { IJsonUploader } from '../types';
-import * as https from 'https';
-import * as http from 'http';
+// import * as https from 'https';
+// import * as http from 'http';
 
 export default class JsonUploader implements IJsonUploader {
   async upload(url: string, jsonData: string): Promise<string> {
     return await new Promise((resolve, reject) => {
-      let httpHandler: any = http;
-      const options = {
-        method: 'POST',
-        path: '/post',
-        headers: {
-          'Content-Type': 'application/json',
-          'Content-Length': Buffer.byteLength(jsonData, 'utf8')
-        }
-      };
-      if (url.startsWith('https')) {
-        httpHandler = https;
-      }
-      const req = httpHandler.request(url, options, (res) => {
-        if (res.statusCode === 200) {
-          res.setEncoding('utf8');
-          let responseBody = '';
-          res.on('data', (chunk) => {
-            // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-            responseBody += chunk;
-          });
-          res.on('end', () => {
-            resolve(responseBody);
-          });
-        } else {
-          reject(new Error(`Received non-200 status code`));
-        }
-      });
-      req.on('error', (e) => {
-        reject(e);
-      });
-      req.write(jsonData);
-      req.end();
+      resolve('');
+      // let httpHandler: any = http;
+      // const options = {
+      //   method: 'POST',
+      //   path: '/post',
+      //   headers: {
+      //     'Content-Type': 'application/json',
+      //     'Content-Length': Buffer.byteLength(jsonData, 'utf8')
+      //   }
+      // };
+      // if (url.startsWith('https')) {
+      //   httpHandler = https;
+      // }
+      // const req = httpHandler.request(url, options, (res) => {
+      //   if (res.statusCode === 200) {
+      //     res.setEncoding('utf8');
+      //     let responseBody = '';
+      //     res.on('data', (chunk) => {
+      //       // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+      //       responseBody += chunk;
+      //     });
+      //     res.on('end', () => {
+      //       resolve(responseBody);
+      //     });
+      //   } else {
+      //     reject(new Error(`Received non-200 status code`));
+      //   }
+      // });
+      // req.on('error', (e) => {
+      //   reject(e);
+      // });
+      // req.write(jsonData);
+      // req.end();
     });
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
       "experimentalDecorators": true,
       "strictNullChecks": true,
       "target": "ES2015",
-      "sourceMap": true,
+      "sourceMap": false,
       "lib": [
         "ES2015"
       ]


### PR DESCRIPTION
- Exclude importing http/https modules for now. 
    - In Long term, figure out how to exclude a directory from compilation.
- Don't generate source maps. 
   - RN is throwing warnings when it doesnt find source files. 
