### PR TITLE
Disabiling Reflector for React Native

### DIFF
--- a/packages/client/src/browser/dispatcher.ts
+++ b/packages/client/src/browser/dispatcher.ts
@@ -8,6 +8,9 @@ declare global {
 
 class EventDispatcher implements IEventDispatcher {
   dispatch(event: ExternalEvent): void {
+    if (navigator.product === 'ReactNative') {
+      return;
+    }
     window.dispatchEvent(
       new CustomEvent(event.type, {
         detail: event.detail

--- a/packages/client/src/utils.ts
+++ b/packages/client/src/utils.ts
@@ -133,7 +133,7 @@ export function convertCase(val: string, to: NamingCase): string {
 
 export type Callback = () => void;
 export function onLoadCallback(callback: Callback): void {
-  if (typeof window === 'undefined') {
+  if (typeof window === 'undefined' || navigator.product === 'ReactNative') {
     callback();
     return;
   }


### PR DESCRIPTION
Our reflector extension is implemented by leveraging `window` as a event emitter.

This doesn't translate well on node and react-native. We need a different solution for them. something like: https://github.com/ai/nanoevents

Until we figure that out, I am disabling the functionality for RN.