### PR TITLE
Rollback local file based dependency.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12321,9 +12321,9 @@
       "dependencies": {
         "@es-joy/jsdoccomment": "^0.37.0",
         "@puppeteer/replay": "^2.11.1",
-        "@syftdata/codehandler": "file:../codehandler",
-        "@syftdata/common": "file:../common",
-        "@syftdata/test": "file:../test",
+        "@syftdata/codehandler": "*",
+        "@syftdata/common": "*",
+        "@syftdata/test": "*",
         "@typescript-eslint/eslint-plugin": "^5.51.0",
         "@typescript-eslint/parser": "^5.51.0",
         "chalk": "^4.1",
@@ -12677,7 +12677,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@es-joy/jsdoccomment": "^0.37.0",
-        "@syftdata/common": "file:../common",
+        "@syftdata/common": "*",
         "handlebars": "^4.7.7",
         "ts-morph": "^17.0.1"
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -69,9 +69,9 @@
   "dependencies": {
     "@es-joy/jsdoccomment": "^0.37.0",
     "@puppeteer/replay": "^2.11.1",
-    "@syftdata/codehandler": "file:../codehandler",
-    "@syftdata/common": "file:../common",
-    "@syftdata/test": "file:../test",
+    "@syftdata/codehandler": "*",
+    "@syftdata/common": "*",
+    "@syftdata/test": "*",
     "@typescript-eslint/eslint-plugin": "^5.51.0",
     "@typescript-eslint/parser": "^5.51.0",
     "chalk": "^4.1",

--- a/packages/codehandler/package.json
+++ b/packages/codehandler/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@es-joy/jsdoccomment": "^0.37.0",
-    "@syftdata/common": "file:../common",
+    "@syftdata/common": "*",
     "handlebars": "^4.7.7",
     "ts-morph": "^17.0.1"
   }

--- a/packages/devtool-extension/src/background/index.ts
+++ b/packages/devtool-extension/src/background/index.ts
@@ -142,7 +142,7 @@ async function handleMessageAsync(
   message: any,
   port: chrome.runtime.Port
 ): Promise<boolean> {
-  console.debug("[Syft][Background] Received a message from Devtools", message);
+  console.debug("[Syft][Background] Received a message", message, port);
   switch (message.type) {
     case MessageType.InitDevTools:
       connections[message.tabId] = port;
@@ -168,6 +168,7 @@ async function handleMessageAsync(
 chrome.runtime.onConnect.addListener(async function (port) {
   console.debug("[Syft][Background] Received a connection", port);
   if (port.name !== "syft-devtools") {
+    console.debug("[Syft][Background] Ignoring the connection");
     return;
   }
 
@@ -212,6 +213,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
       console.warn(
         "Tab not found in connection list.",
         request,
+        sender.tab,
         tabId,
         Object.keys(connections)
       );
@@ -223,7 +225,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
       sendResponse(true);
     } else {
       console.warn(
-        "Tab not found in connection list.",
+        "Tab not found in connection list 2.",
         request,
         tabId,
         Object.keys(connections)

--- a/packages/devtool-extension/src/cloud/api/git.ts
+++ b/packages/devtool-extension/src/cloud/api/git.ts
@@ -18,10 +18,13 @@ export function downloadFile(name: string, contents: string): void {
   a.remove();
 }
 
-async function handleGitInfoResponse(response: Response): Promise<void> {
+async function handleGitInfoResponse(
+  response: Response
+): Promise<GitInfo | undefined> {
   if (response.ok) {
     const data = (await response.json()) as GitInfo;
     setGitInfo(data);
+    return data;
   } else {
     console.error("Error fetching git info", response);
   }
@@ -31,12 +34,12 @@ export async function fetchGitInfo(
   user: UserSession,
   sourceId?: string,
   branch?: string
-): Promise<void> {
+): Promise<GitInfo | undefined> {
   const response = await get("/api/gitinfo", user, {
     sourceId,
     branch,
   });
-  handleGitInfoResponse(response);
+  return handleGitInfoResponse(response);
 }
 
 export async function createTestSpec(

--- a/packages/devtool-extension/src/devpanel/index.tsx
+++ b/packages/devtool-extension/src/devpanel/index.tsx
@@ -34,6 +34,9 @@ function init(
       onActions(message.data as Action[]);
     } else if (message.type === MessageType.OnShown) {
       // refresh connection and re-fetch git info.
+      console.debug(
+        "OnShown called. refreshing connection and re-fetching git info."
+      );
       refreshConnection();
       getUserSession().then((userSession) => {
         if (userSession != null) {


### PR DESCRIPTION
local file based dependency is not working when using it as a library. customers need to install @syftdata/common and @syftdata/codehandler manually as a workaround, which is not convenient. Rolling back this change. 