### PR TITLE
Update plugins with package field and add functionality to store each…

### DIFF
--- a/packages/cli/src/commands/init-client.ts
+++ b/packages/cli/src/commands/init-client.ts
@@ -1,0 +1,108 @@
+import type * as yargs from 'yargs';
+import { getSchemaFolder } from '../utils';
+import {
+  logDetail,
+  logError,
+  logInfo,
+  logUnknownError,
+  logVerbose
+} from '@syftdata/common/lib/utils';
+import * as fs from 'fs';
+import * as path from "path";
+import { handler as generateFromDir } from './generate';
+import { fetchRemoteData } from '../init/destination';
+import type { AST } from '@syftdata/common/lib/types';
+import { getEventShemas } from '../init/local';
+import { writeTestSpecs } from '../publish/remote';
+import { serialize } from '@syftdata/codehandler';
+import { ModuleKind, Project, ScriptTarget } from 'ts-morph';
+import {getClientPackage} from "../config/pkg";
+import {PluginDependency} from "@syftdata/client/src";
+import {generate} from "../codegen/generators/ts_generator";
+
+export interface Params {
+  platform: string;
+  product: string;
+  outDir: string;
+  apikey?: string;
+  branch?: string;
+  remote: string;
+  force: boolean;
+}
+
+export const command = 'init-client';
+export const desc = 'Initialize Syft project. Generates Event models.';
+export const builder = (y: yargs.Argv): yargs.Argv => {
+  return y;
+};
+
+function getMetricsProvider(packageJson?: any): string | null {
+  if (packageJson != null) {
+    const dependencies = packageJson.dependencies;
+
+    for (const value in PluginDependency) {
+      if (dependencies.hasOwnProprety(value) === true) {
+        return PluginDependency[value];
+      }
+    }
+  }
+  // nothing found
+  return null;
+}
+
+async function createSyftTS(ast: AST, folder: string): Promise<void> {
+  const metricsProvider = await getClientPackage().then((val) => {
+    return getMetricsProvider(val.json);
+  });
+  if (metricsProvider == null) {
+    logError(`:warning: No package.json file found. Exiting...`);
+    return;
+  }
+  const src = getSchemaFolder();
+  logVerbose(`Writing syft.ts to src directory...`);
+
+  const srcPath = path.relative('../../assets', 'syft.ts');
+  generate()
+
+}
+
+export async function handler(): Promise<void> {
+  logVerbose(`Initializing Syft in ${outDir}..`);
+  let ast: AST;
+  if (apikey !== undefined) {
+    logVerbose(`Pulling from ${remote}..`);
+    try {
+      const remoteData = await fetchRemoteData(remote, apikey, branch);
+      if (remoteData === undefined) {
+        logError(`:warning: Failed to fetch data from ${remote}`);
+        return;
+      }
+      ast = remoteData.ast;
+      if (ast.eventSchemas.length === 0) {
+        logError(`:warning: No event models found. Exiting..`);
+        return;
+      }
+      initalizeSchemaFolder(outDir, force);
+      writeTestSpecs(remoteData.tests, outDir);
+      // writeRemoteConfig(
+      //   remoteData.activeBranch,
+      //   remoteData.eventSchemaSha,
+      //   remoteData.tests,
+      //   outDir
+      // );
+    } catch (e) {
+      logUnknownError(`:warning: Failed to fetch data from ${remote}`, e);
+      return;
+    }
+  } else {
+    logVerbose(`Generating models for ${platform}`);
+    ast = getEventShemas(platform, product);
+    initalizeSchemaFolder(outDir, force);
+  }
+
+  generateSchemasFrom(ast, outDir);
+  logInfo(':heavy_check_mark: Syft folder is created.');
+  if (process.env.NODE_ENV !== 'test') {
+    await generateFromDir({ input: outDir, type: 'ts' });
+  }
+}

--- a/packages/client/src/base.ts
+++ b/packages/client/src/base.ts
@@ -1,5 +1,5 @@
 import Batcher from './batcher';
-import { type TestingPlugin } from './plugins';
+import { type TestingPlugin, type TestingPlugin2 } from './plugins';
 import {
   DEFAULT_STATIC_CONFIG,
   DEFAULT_RUNTIME_CONFIG,

--- a/packages/client/src/metrics_dependency_registry.ts
+++ b/packages/client/src/metrics_dependency_registry.ts
@@ -1,0 +1,74 @@
+/**
+ * The following provides functionality to enforce a consistent set of supported metrics dependencies and store them
+ * in a map for easy reference. This map can easily be extended to include additional state that may be required in
+ * the future like version, etc.
+ */
+
+/**
+ * maps dependency name like 'Amplitude' to corresponding DependencyInfo
+ */
+type DependencyMap = Map<string, DependencyInfo>;
+/**
+ * maps pkg name like 'amplitude-js' to corresponding DependencyInfo
+ */
+type PackageMap = Map<string, DependencyInfo>;
+
+export class DependencyInfo {
+  id: string;
+  pkg: string;
+  constructor(id: string, pkg: string) {
+    this.id = id;
+    this.pkg = pkg;
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class
+export abstract class MetricsDependencyRegistry {
+  static dependencyMap: DependencyMap = new Map<string, DependencyInfo>();
+
+  static packageMap: PackageMap = new Map<string, DependencyInfo>();
+
+  private static registerDependency(id: string, pkg: string): void {
+    this.dependencyMap.set(id, new DependencyInfo(id, pkg));
+    this.packageMap.set(pkg, new DependencyInfo(id, pkg));
+  }
+
+  static getDependencyMap(): DependencyMap {
+    return this.dependencyMap;
+  }
+
+  static getPackageMap(): PackageMap {
+    return this.packageMap;
+  }
+
+  static registerDependencies(): void {
+    const keys = Object.getOwnPropertyNames(this.prototype);
+    for (const key of keys) {
+      if (key === 'pkg' || key === 'id') {
+        const value = this.prototype[key];
+        if (typeof value === 'string') {
+          this.registerDependency(value, key);
+        }
+      }
+    }
+  }
+
+  protected static register(): void {}
+}
+
+interface IMetricsDependency extends MetricsDependencyRegistry {
+  pkg: string;
+  id: string;
+}
+
+/**
+ * All Plugins need to extend this. Right now we are extending it via ISyftPlugin.
+ */
+export abstract class MetricsDependency implements IMetricsDependency {
+  pkg!: string;
+  id!: string;
+
+  protected static register(): void {
+    MetricsDependencyRegistry.registerDependencies.call(this);
+  }
+}

--- a/packages/client/src/plugins/Amplitude.ts
+++ b/packages/client/src/plugins/Amplitude.ts
@@ -5,6 +5,7 @@ import {
   type SyftEvent,
   type ISyftPlugin
 } from '../types';
+import {MetricsDependency} from "../metrics_dependency_registry";
 
 declare global {
   interface Window {
@@ -45,8 +46,9 @@ class Plugin {
   async setup(): Promise<void> {}
 }
 
-export class AmplitudePlugin implements ISyftPlugin {
+export class AmplitudePlugin implements ISyftPlugin, MetricsDependency {
   id = 'Amplitude';
+  pkg = 'amplitude-js';
   amplitude: any;
   isBrowser = typeof window !== 'undefined';
 

--- a/packages/client/src/plugins/GA4.ts
+++ b/packages/client/src/plugins/GA4.ts
@@ -3,7 +3,7 @@ import {
   type IReflector,
   SyftEventType,
   type SyftEvent,
-  type ISyftPlugin
+  type ISyftPlugin,
 } from '../types';
 
 declare global {
@@ -15,6 +15,7 @@ declare global {
 
 export class GA4Plugin implements ISyftPlugin {
   id = 'GA4';
+  pkg = 'react-ga4';
   syft: Syft;
   gtag: any;
   isBrowser = typeof window !== 'undefined';
@@ -89,6 +90,9 @@ export class GA4Plugin implements ISyftPlugin {
     if (this.gtag != null) {
       this.gtag.reset();
     }
+  }
+
+  setProvider(): void {
   }
 }
 

--- a/packages/client/src/plugins/Heap.ts
+++ b/packages/client/src/plugins/Heap.ts
@@ -13,6 +13,7 @@ declare global {
 
 export class HeapPlugin implements ISyftPlugin {
   id = 'Heap';
+  pkg = '@heap/react-heap';
   isBrowser = typeof window !== 'undefined';
   heap: any;
 

--- a/packages/client/src/plugins/MixPanel.ts
+++ b/packages/client/src/plugins/MixPanel.ts
@@ -3,7 +3,7 @@ import {
   type IReflector,
   SyftEventType,
   type SyftEvent,
-  type ISyftPlugin
+  ISyftPlugin
 } from '../types';
 
 declare global {
@@ -36,6 +36,7 @@ declare global {
 
 export class MixPanelPlugin implements ISyftPlugin {
   id = 'MixPanel';
+  pkg = 'mixpanel-browser';
   mixpanel: any;
   isBrowser = typeof window !== 'undefined';
 

--- a/packages/client/src/plugins/Segment.ts
+++ b/packages/client/src/plugins/Segment.ts
@@ -70,6 +70,7 @@ class Plugin {
  */
 export class SegmentPlugin implements ISyftPlugin {
   id = 'Segment';
+  pkg = 'analytics-node';
   syft: Syft;
   analytics: any;
   isBrowser = typeof window !== 'undefined';

--- a/packages/client/src/plugins/TestingPlugin2.ts
+++ b/packages/client/src/plugins/TestingPlugin2.ts
@@ -1,8 +1,9 @@
 import type { SyftEvent, ISyftPlugin, IReflector } from '../types';
+import {MetricsDependency} from "../metrics_dependency_registry";
 
-export class TestingPlugin implements ISyftPlugin {
-  id = 'TestingPlugin';
-  pkg = 'testing-plugin';
+export class TestingPlugin2 implements ISyftPlugin {
+  id = 'TestingPlugin2';
+  pkg = 'testing-plugin2';
   events: SyftEvent[] = [];
 
   isLoaded(): boolean {
@@ -31,4 +32,4 @@ export class TestingPlugin implements ISyftPlugin {
   resetUserProperties(): void {}
 }
 
-export default TestingPlugin;
+export default TestingPlugin2;

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -1,4 +1,5 @@
 import type { ApiEvent } from './monitor/types';
+import type { MetricsDependency } from './metrics_dependency_registry';
 
 export enum SyftEventType {
   TRACK,
@@ -123,9 +124,7 @@ export interface IReflector {
   ) => void;
 }
 
-export interface ISyftPlugin {
-  id: string;
-
+export interface ISyftPlugin extends MetricsDependency {
   /**
    * Gives you an opportunity to start loading the plugin dependencies
    */

--- a/packages/client/tests/batcher.test.ts
+++ b/packages/client/tests/batcher.test.ts
@@ -1,4 +1,4 @@
-import { type IReflector } from '../lib';
+import { type IReflector } from '../src';
 import Batcher from '../src/batcher';
 import {
   type ISyftPlugin,
@@ -21,6 +21,7 @@ interface TestEvent extends SyftEvent {
 
 function getMockPlugin(id: string): ISyftPlugin {
   return {
+    pkg: "",
     id,
     init: jest.fn(() => {}),
     logEvent: jest.fn(() => {

--- a/packages/client/tests/metrics_dependency_registry.test.ts
+++ b/packages/client/tests/metrics_dependency_registry.test.ts
@@ -1,0 +1,34 @@
+import {DependencyInfo, MetricsDependencyRegistry} from "../src/metrics_dependency_registry";
+import { TestingPlugin, TestingPlugin2 } from "../src";
+
+describe('MetricsDependencyRegistry', () => {
+  beforeAll(() => {
+    // Reset the dependency maps before all tests
+    MetricsDependencyRegistry.dependencyMap = new Map<string, DependencyInfo>();
+  });
+
+  it('should register dependencies correctly', () => {
+    new TestingPlugin();
+    new TestingPlugin2();
+
+    const expectedPackageMap = new Map<string, DependencyInfo>([
+      ['TestingPlugin', new DependencyInfo('TestingPlugin', 'testing-plugin')],
+      ['TestingPlugin2', new DependencyInfo('TestingPlugin2', 'testing-plugin2')],
+    ]);
+    const actualPackageMap = MetricsDependencyRegistry.getPackageMap();
+    expect(actualPackageMap.size).toBe(expectedPackageMap.size);
+    for (let [key, value] of expectedPackageMap) {
+      expect(actualPackageMap.get(key)).toEqual(value);
+    }
+
+    const expectedDepMap = new Map<string, DependencyInfo>([
+      ['testing-plugin', new DependencyInfo('TestingPlugin', 'testing-plugin')],
+      ['testing-plugin2', new DependencyInfo('TestingPlugin2', 'testing-plugin2')],
+    ]);
+    const actualDepMap = MetricsDependencyRegistry.getDependencyMap();
+    expect(actualDepMap.size).toBe(expectedDepMap.size);
+    for (let [key, value] of expectedDepMap) {
+      expect(actualDepMap.get(key)).toEqual(value);
+    }
+  });
+});


### PR DESCRIPTION
… plugin's corresponding metric dependency into into a map.

This will allow me to safely iterate through the list of supported metrics providers and generate the syft.ts file. Any new provider will automatically be covered since the map of metrics dependency information is automatically generated for anything implementing ISyftPlugin.

I'm still fixing the unit test, but I wanted to get this to you beforehand in case you want changes that would modify how I'm testing.