### PR TITLE
Analyze codebases 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12275,6 +12275,14 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
+    "node_modules/yaml": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
+      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/yargs": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -12359,6 +12367,7 @@
         "node-emoji": "^1.11.0",
         "puppeteer": "^20.2.1",
         "ts-morph": "^17.0.1",
+        "yaml": "^2.3.1",
         "yargs": "^17.6.2"
       },
       "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -82,6 +82,7 @@
     "node-emoji": "^1.11.0",
     "puppeteer": "^20.2.1",
     "ts-morph": "^17.0.1",
+    "yaml": "^2.3.1",
     "yargs": "^17.6.2"
   },
   "gitHead": "88c566d72818936b193d860ced18df01b84bf140"

--- a/packages/cli/src/commands/analyze.ts
+++ b/packages/cli/src/commands/analyze.ts
@@ -16,7 +16,7 @@ export const desc = 'Analyze source directory and extracts schema';
 export const builder = (y: yargs.Argv): yargs.Argv => {
   return y
     .option('output', {
-      describe: 'output folder to create / update events.ts file.',
+      describe: 'output folder to create events.yaml file.',
       type: 'string'
     })
     .option('srcDir', {
@@ -52,7 +52,7 @@ export async function handler({ output, srcDir }: Params): Promise<void> {
   if (output == null) {
     logInfo(yaml);
   } else {
-    const yamlFile = path.join(output, 'event_schema.yaml');
+    const yamlFile = path.join(output, 'events.yaml');
     fs.writeFileSync(yamlFile, yaml, 'utf-8');
   }
 }

--- a/packages/cli/src/commands/analyze.ts
+++ b/packages/cli/src/commands/analyze.ts
@@ -1,0 +1,58 @@
+import type * as yargs from 'yargs';
+import * as path from 'path';
+import * as fs from 'fs';
+import { logInfo } from '@syftdata/common/lib/utils';
+import { readTSProject, analyzeAST } from '@syftdata/codehandler';
+import { stringify } from 'yaml';
+import { SyftEventType } from '@syftdata/client';
+
+export interface Params {
+  output: string;
+  srcDir: string;
+}
+
+export const command = 'analyze';
+export const desc = 'Analyze source directory and extracts schema';
+export const builder = (y: yargs.Argv): yargs.Argv => {
+  return y
+    .option('output', {
+      describe: 'output folder to create / update events.ts file.',
+      type: 'string'
+    })
+    .option('srcDir', {
+      describe: 'Directory to find project source code',
+      type: 'string',
+      default: '.'
+    });
+};
+
+export async function handler({ output, srcDir }: Params): Promise<void> {
+  const tsProject = readTSProject(srcDir);
+  if (tsProject == null) {
+    return;
+  }
+  const project = tsProject.project;
+  logInfo('Analyzing the code to find usages..');
+  const ast = analyzeAST(project);
+  // put the yaml into a file.
+  const yaml = stringify(
+    ast.eventSchemas,
+    (k, v) => {
+      if (k === 'eventType') {
+        return SyftEventType[v];
+      }
+      if (k === 'zodType') return;
+      if (k === 'type') {
+        return v.name;
+      }
+      return v;
+    },
+    2
+  );
+  if (output == null) {
+    logInfo(yaml);
+  } else {
+    const yamlFile = path.join(output, 'event_schema.yaml');
+    fs.writeFileSync(yamlFile, yaml, 'utf-8');
+  }
+}

--- a/packages/codehandler/src/analyzers/index.ts
+++ b/packages/codehandler/src/analyzers/index.ts
@@ -1,0 +1,98 @@
+import { NamingCase, type SyftEventType } from '@syftdata/client';
+import { convertCase } from '@syftdata/client/lib/utils';
+import {
+  type TypeField,
+  type AST,
+  type EventSchema,
+  type Field
+} from '@syftdata/common/lib/types';
+import { type Project } from 'ts-morph';
+import { AmplitudeAnalyser } from './plugins/amplitude';
+import { GAAnalyser } from './plugins/gtag';
+import { handleSourceFile } from './plugins/base';
+
+export interface Usage {
+  eventType: SyftEventType;
+  eventName: string;
+  typeFields: TypeField[];
+}
+
+function isEqualType(type1: TypeField, type2: TypeField): boolean {
+  // TODO compare types.
+  return true;
+}
+function getEventSchema(name: string, usageArray: Usage[]): EventSchema {
+  const fieldNameToTypeMap = new Map<string, TypeField>();
+  const fieldNameToCount = new Map<string, number>();
+  usageArray.forEach((usage) => {
+    usage.typeFields.forEach((field) => {
+      const existingType = fieldNameToTypeMap.get(field.name);
+      fieldNameToCount.set(
+        field.name,
+        (fieldNameToCount.get(field.name) ?? 0) + 1
+      );
+      if (existingType != null && !isEqualType(existingType, field)) {
+        console.error(
+          `Found incompatible field types for ${name}.${field.name} `
+        );
+      } else {
+        fieldNameToTypeMap.set(field.name, field);
+      }
+    });
+  });
+
+  const fields: Field[] = [...fieldNameToTypeMap.entries()].map((entry) => {
+    const fieldName = entry[0];
+    const type = entry[1];
+    const field: Field = {
+      name: fieldName,
+      type: {
+        ...type.type,
+        name: type.type.name,
+        zodType: type.type.zodType
+      },
+      isOptional:
+        type.isOptional ||
+        (fieldNameToCount.get(fieldName) ?? 0) < usageArray.length
+    };
+    return field;
+  });
+
+  return {
+    name: convertCase(name, NamingCase.PASCAL),
+    eventType: usageArray[0].eventType,
+    fields,
+    zodType: ''
+  };
+}
+
+export function analyzeAST(project: Project): AST {
+  let usageDetails: Usage[] = [];
+  const sourceFiles = project.getSourceFiles();
+  const plugins = [new AmplitudeAnalyser(), new GAAnalyser()];
+  sourceFiles.forEach((sourceFile) => {
+    usageDetails = usageDetails.concat(handleSourceFile(sourceFile, plugins));
+  });
+
+  // merge usageDetails into arrays based on eventName field.
+  const usageMapByEventName = new Map<string, Usage[]>();
+  usageDetails.forEach((usage) => {
+    const eventName = usage.eventName;
+    if (usageMapByEventName.has(eventName)) {
+      usageMapByEventName.get(eventName)?.push(usage);
+    } else {
+      usageMapByEventName.set(eventName, [usage]);
+    }
+  });
+  const eventSchemas = Array.from(usageMapByEventName.entries()).map(
+    ([eventName, usageDetails]) => getEventSchema(eventName, usageDetails)
+  );
+
+  return {
+    eventSchemas,
+    config: {
+      projectName: 'Test',
+      version: '0.0.1'
+    }
+  };
+}

--- a/packages/codehandler/src/analyzers/plugins/amplitude.ts
+++ b/packages/codehandler/src/analyzers/plugins/amplitude.ts
@@ -1,0 +1,44 @@
+import { SyftEventType } from '@syftdata/common/lib/client_types';
+import { BaseAnalyser, extractEventNameAndFields } from './base';
+import { type Node, type ts } from 'ts-morph';
+import { type Usage } from '..';
+
+export class AmplitudeAnalyser extends BaseAnalyser {
+  isAMatch(expression: string): SyftEventType | undefined {
+    if (expression.endsWith('.track')) {
+      return SyftEventType.TRACK;
+    }
+    if (expression.endsWith('.page')) {
+      return SyftEventType.PAGE;
+    }
+    if (expression.endsWith('.identify')) {
+      return SyftEventType.IDENTIFY;
+    }
+    if (expression.endsWith('.setGroup')) {
+      return SyftEventType.GROUP_IDENTIFY;
+    }
+    return super.isAMatch(expression);
+  }
+
+  getUsage(
+    method: string,
+    type: SyftEventType,
+    args: Array<Node<ts.Node>>
+  ): Usage | undefined {
+    const usage = extractEventNameAndFields(method, args, type);
+    if (type === SyftEventType.IDENTIFY) {
+      if (usage != null) {
+        usage.typeFields.push({
+          name: usage.eventName,
+          type: {
+            name: 'string',
+            zodType: 'z.string()'
+          },
+          isOptional: false
+        });
+        usage.eventName = 'UserIdentify';
+      }
+    }
+    return usage;
+  }
+}

--- a/packages/codehandler/src/analyzers/plugins/base.ts
+++ b/packages/codehandler/src/analyzers/plugins/base.ts
@@ -1,0 +1,91 @@
+import { SyftEventType } from '@syftdata/client';
+import { type Usage } from '..';
+import { SyntaxKind, type SourceFile, type Node, type ts } from 'ts-morph';
+import { getTypeSchema } from '../../deserializer/ts_morph_utils';
+
+export abstract class BaseAnalyser {
+  isAMatch(expression: string): SyftEventType | undefined {
+    return undefined;
+  }
+
+  getUsage(
+    method: string,
+    type: SyftEventType,
+    args: Array<Node<ts.Node>>
+  ): Usage | undefined {
+    return undefined;
+  }
+}
+
+export function handleSourceFile(
+  sourceFile: SourceFile,
+  plugins: BaseAnalyser[]
+): Usage[] {
+  const callExpressions = sourceFile.getDescendantsOfKind(
+    SyntaxKind.CallExpression
+  );
+  return plugins.flatMap((plugin) => {
+    const usages = callExpressions.map((callExpression) => {
+      const expression = callExpression.getExpression();
+      return { callExpression, type: plugin.isAMatch(expression.getText()) };
+    });
+    return usages
+      .map(({ callExpression, type }) => {
+        if (type === undefined) return undefined;
+        const method = callExpression.getExpression().getText();
+        const args = callExpression.getArguments();
+
+        if (args.length === 0) return undefined;
+        return plugin.getUsage(method, type, args);
+      })
+      .filter((a) => a != null) as Usage[];
+  });
+}
+
+export function extractEventNameAndFields(
+  method: string,
+  args: Array<Node<ts.Node>>,
+  eventType: SyftEventType = SyftEventType.TRACK
+): Usage | undefined {
+  const eventNameArg = args[0];
+  let eventProperties = args.slice(1);
+  let eventName: string | undefined;
+  let eventNameType = eventNameArg.getType();
+
+  if (args.length <= 1) {
+    // args and event-name might be merged into one ?
+    if (eventNameArg.isKind(SyntaxKind.ObjectLiteralExpression)) {
+      const fields = eventNameArg.getChildrenOfKind(
+        SyntaxKind.PropertyAssignment
+      );
+      const field = fields.find(
+        (field) =>
+          field.getName() === 'event_name' || field.getName() === 'eventName'
+      );
+      if (field?.getInitializer() != null) {
+        eventNameType = (field.getInitializer() as any).getType();
+      }
+      // TODO: strip off this field from the schema.
+      eventProperties = args;
+    }
+  }
+
+  if (eventNameType.isStringLiteral()) {
+    eventName = eventNameType.getLiteralValue() as string;
+  } else {
+    eventName = eventNameType.getText();
+  }
+
+  if (eventName == null) return undefined;
+
+  const argTypes = eventProperties.map((arg) => {
+    return getTypeSchema(arg.getType(), method);
+  });
+  const typeFields = argTypes.at(0)?.typeFields ?? [];
+  const usageDetail: Usage = {
+    eventType,
+    eventName,
+    typeFields
+  };
+  return usageDetail;
+}

--- a/packages/codehandler/src/analyzers/plugins/gtag.ts
+++ b/packages/codehandler/src/analyzers/plugins/gtag.ts
@@ -1,0 +1,47 @@
+import { SyftEventType } from '@syftdata/common/lib/client_types';
+import { BaseAnalyser, extractEventNameAndFields } from './base';
+import { type Node, type ts } from 'ts-morph';
+import { type Usage } from '..';
+
+export class GAAnalyser extends BaseAnalyser {
+  isAMatch(expression: string): SyftEventType | undefined {
+    if (expression.endsWith('gtag')) {
+      return SyftEventType.TRACK;
+    }
+    return undefined;
+  }
+
+  getUsage(
+    method: string,
+    type: SyftEventType,
+    args: Array<Node<ts.Node>>
+  ): Usage | undefined {
+    // based on the first arg, we decide if it is track, identify or global.
+    let realType: SyftEventType | undefined;
+    const typeName = args[0].getType().getLiteralValue() as string;
+    if (typeName === 'event') {
+      realType = SyftEventType.TRACK;
+    } else if (typeName === 'set') {
+      realType = SyftEventType.IDENTIFY;
+    }
+
+    if (realType == null) return undefined;
+
+    const realArgs = args.slice(1);
+    const usage = extractEventNameAndFields(method, realArgs, realType);
+    if (realType === SyftEventType.IDENTIFY) {
+      if (usage != null) {
+        usage.typeFields.push({
+          name: usage.eventName,
+          type: {
+            name: 'string',
+            zodType: 'z.string()'
+          },
+          isOptional: false
+        });
+        usage.eventName = 'UserIdentify';
+      }
+    }
+    return usage;
+  }
+}

--- a/packages/codehandler/src/analyzers/plugins/mixpanel.ts
+++ b/packages/codehandler/src/analyzers/plugins/mixpanel.ts
@@ -1,0 +1,41 @@
+import { SyftEventType } from '@syftdata/common/lib/client_types';
+import { BaseAnalyser, extractEventNameAndFields } from './base';
+import { type Node, type ts } from 'ts-morph';
+import { type Usage } from '..';
+
+export class MixpanelAnalyser extends BaseAnalyser {
+  isAMatch(expression: string): SyftEventType | undefined {
+    if (expression.endsWith('.track')) {
+      return SyftEventType.TRACK;
+    }
+    if (expression.endsWith('.page')) {
+      return SyftEventType.PAGE;
+    }
+    if (expression.endsWith('.people.set')) {
+      return SyftEventType.IDENTIFY;
+    }
+    return super.isAMatch(expression);
+  }
+
+  getUsage(
+    method: string,
+    type: SyftEventType,
+    args: Array<Node<ts.Node>>
+  ): Usage | undefined {
+    const usage = extractEventNameAndFields(method, args, type);
+    if (type === SyftEventType.IDENTIFY) {
+      if (usage != null) {
+        usage.typeFields.push({
+          name: 'id',
+          type: {
+            name: 'string',
+            zodType: 'z.string()'
+          },
+          isOptional: false
+        });
+        usage.eventName = 'UserIdentify';
+      }
+    }
+    return usage;
+  }
+}

--- a/packages/codehandler/src/deserializer/visitor.ts
+++ b/packages/codehandler/src/deserializer/visitor.ts
@@ -26,7 +26,6 @@ function getField(
   typeFields?: Map<string, TypeField>
 ): Field | undefined {
   const tags = getTags(property.getJsDocs());
-  const isOptional = property.hasQuestionToken();
 
   const typeField = typeFields?.get(property.getName());
   if (typeField == null) {
@@ -54,19 +53,13 @@ function getField(
     });
   }
 
-  if (isOptional) {
-    zodType = `${zodType}.optional()`;
-  }
-  typeField.type.zodType = zodType;
-
   return {
     ...typeField,
     documentation: property
       .getJsDocs()
       .map((doc) => doc.getInnerText())
       .join('\n'),
-    defaultValue: property.getInitializer()?.getText(),
-    isOptional
+    defaultValue: property.getInitializer()?.getText()
   };
 }
 

--- a/packages/codehandler/src/deserializer/zod_utils.ts
+++ b/packages/codehandler/src/deserializer/zod_utils.ts
@@ -24,7 +24,7 @@ export function getZodType(
   enumValues: string[],
   syfttype?: string
 ): string {
-  if (enumValues.length > 0) {
+  if (enumValues.length > 1) {
     // For Enum, return in the format of enum(["Salmon", "Tuna", "Trout"])
     return `enum([${enumValues.join(', ')}])`;
   }

--- a/packages/codehandler/src/index.ts
+++ b/packages/codehandler/src/index.ts
@@ -2,3 +2,9 @@ export * from './serializer/ts_model';
 export * from './deserializer/ts_model';
 export * from './generators/ts_generator';
 export * from './deserializer/zod_utils';
+
+export * from './analyzers';
+export * from './analyzers/plugins/base';
+export * from './analyzers/plugins/amplitude';
+export * from './analyzers/plugins/gtag';
+export * from './analyzers/plugins/mixpanel';

--- a/packages/codehandler/tests/analyzers/__snapshots__/index.test.ts.snap
+++ b/packages/codehandler/tests/analyzers/__snapshots__/index.test.ts.snap
@@ -43,7 +43,7 @@ exports[`analyze source code finds amplitude usages 1`] = `
           "name": "number",
           "zodType": "z.number()"
         },
-        "isOptional": false
+        "isOptional": true
       },
       {
         "name": "arg2",
@@ -52,6 +52,14 @@ exports[`analyze source code finds amplitude usages 1`] = `
           "zodType": "z.boolean()"
         },
         "isOptional": false
+      },
+      {
+        "name": "arg3",
+        "type": {
+          "name": "string",
+          "zodType": "z.string()"
+        },
+        "isOptional": true
       }
     ],
     "zodType": ""

--- a/packages/codehandler/tests/analyzers/__snapshots__/index.test.ts.snap
+++ b/packages/codehandler/tests/analyzers/__snapshots__/index.test.ts.snap
@@ -1,0 +1,137 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`analyze source code finds amplitude usages 1`] = `
+"[
+  {
+    "name": "EventAmpli1",
+    "eventType": 0,
+    "fields": [
+      {
+        "name": "argOpt",
+        "type": {
+          "name": "number",
+          "zodType": "z.number().optional()"
+        },
+        "isOptional": true
+      },
+      {
+        "name": "arg2",
+        "type": {
+          "name": "boolean",
+          "zodType": "z.boolean()"
+        },
+        "isOptional": false
+      }
+    ],
+    "zodType": ""
+  },
+  {
+    "name": "EventAmpli2",
+    "eventType": 0,
+    "fields": [
+      {
+        "name": "eventName",
+        "type": {
+          "name": "string",
+          "zodType": "z.string()"
+        },
+        "isOptional": false
+      },
+      {
+        "name": "arg1",
+        "type": {
+          "name": "number",
+          "zodType": "z.number()"
+        },
+        "isOptional": false
+      },
+      {
+        "name": "arg2",
+        "type": {
+          "name": "boolean",
+          "zodType": "z.boolean()"
+        },
+        "isOptional": false
+      }
+    ],
+    "zodType": ""
+  },
+  {
+    "name": "EventAmpliPage",
+    "eventType": 1,
+    "fields": [
+      {
+        "name": "path",
+        "type": {
+          "name": "string",
+          "zodType": "z.string()"
+        },
+        "isOptional": false
+      },
+      {
+        "name": "arg2",
+        "type": {
+          "name": "boolean",
+          "zodType": "z.boolean()"
+        },
+        "isOptional": false
+      }
+    ],
+    "zodType": ""
+  },
+  {
+    "name": "EventGa1",
+    "eventType": 0,
+    "fields": [
+      {
+        "name": "arg1",
+        "type": {
+          "name": "number",
+          "zodType": "z.number()"
+        },
+        "isOptional": false
+      },
+      {
+        "name": "arg2",
+        "type": {
+          "name": "boolean",
+          "zodType": "z.boolean()"
+        },
+        "isOptional": false
+      }
+    ],
+    "zodType": ""
+  },
+  {
+    "name": "UserIdentify",
+    "eventType": 3,
+    "fields": [
+      {
+        "name": "userid",
+        "type": {
+          "name": "number",
+          "zodType": "z.number()"
+        },
+        "isOptional": false
+      },
+      {
+        "name": "email",
+        "type": {
+          "name": "string",
+          "zodType": "z.string()"
+        },
+        "isOptional": false
+      },
+      {
+        "name": "user",
+        "type": {
+          "name": "string",
+          "zodType": "z.string()"
+        },
+        "isOptional": false
+      }
+    ],
+    "zodType": ""
+  }
+]"
+`;

--- a/packages/codehandler/tests/analyzers/index.test.ts
+++ b/packages/codehandler/tests/analyzers/index.test.ts
@@ -1,0 +1,13 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { analyzeAST } from '../../src/analyzers/index';
+import { createTSProject } from '../../src/deserializer/ts_model';
+
+describe('analyze source code', () => {
+  it('finds amplitude usages', async () => {
+    const proj = createTSProject(['./tests/test_project/']);
+    const ast = analyzeAST(proj);
+
+    // expect(ast.eventSchemas).toHaveLength(4);
+    expect(JSON.stringify(ast?.eventSchemas, null, 2)).toMatchSnapshot();
+  });
+});

--- a/packages/codehandler/tests/deserializer/__snapshots__/ts_model.test.ts.snap
+++ b/packages/codehandler/tests/deserializer/__snapshots__/ts_model.test.ts.snap
@@ -10,59 +10,59 @@ exports[`generateASTForProject with event annotations 1`] = `
     "fields": [
       {
         "name": "userId",
+        "isOptional": false,
         "type": {
           "name": "string",
           "syfttype": "UUID",
           "zodType": "z.string().uuid()"
         },
-        "isOptional": false,
         "documentation": ""
       },
       {
         "name": "email",
+        "isOptional": false,
         "type": {
           "name": "string",
           "syfttype": "Email",
           "zodType": "z.string().email()"
         },
-        "isOptional": false,
         "documentation": ""
       },
       {
         "name": "country",
+        "isOptional": false,
         "type": {
           "name": "string",
           "syfttype": "CountryCode",
           "zodType": "z.string().length(2)"
         },
-        "isOptional": false,
         "documentation": ""
       },
       {
         "name": "direction",
+        "isOptional": false,
         "type": {
-          "name": "0 | 1 | 2 | 3",
+          "name": "number",
           "zodType": "z.enum([0, 1, 2, 3])"
         },
-        "isOptional": false,
         "documentation": ""
       },
       {
         "name": "isSpammer",
+        "isOptional": false,
         "type": {
-          "name": "\\"Yes\\" | \\"No\\"",
+          "name": "string",
           "zodType": "z.enum([\\"Yes\\", \\"No\\"])"
         },
-        "isOptional": false,
         "documentation": ""
       },
       {
         "name": "isVerified",
+        "isOptional": false,
         "type": {
           "name": "boolean",
           "zodType": "z.boolean()"
         },
-        "isOptional": false,
         "documentation": ""
       }
     ],
@@ -82,32 +82,32 @@ exports[`generateASTForProject with multiple schemas 1`] = `
     "fields": [
       {
         "name": "userId",
+        "isOptional": false,
         "type": {
           "name": "string",
           "syfttype": "UUID",
           "zodType": "z.string().uuid()"
         },
-        "isOptional": false,
         "documentation": ""
       },
       {
         "name": "email",
+        "isOptional": false,
         "type": {
           "name": "string",
           "syfttype": "Email",
           "zodType": "z.string().email()"
         },
-        "isOptional": false,
         "documentation": ""
       },
       {
         "name": "country",
+        "isOptional": false,
         "type": {
           "name": "string",
           "syfttype": "CountryCode",
           "zodType": "z.string().length(2)"
         },
-        "isOptional": false,
         "documentation": ""
       }
     ],
@@ -122,20 +122,20 @@ exports[`generateASTForProject with multiple schemas 1`] = `
     "fields": [
       {
         "name": "page",
+        "isOptional": false,
         "type": {
           "name": "string",
           "zodType": "z.string()"
         },
-        "isOptional": false,
         "documentation": ""
       },
       {
         "name": "time",
+        "isOptional": false,
         "type": {
           "name": "Date",
           "zodType": "z.date()"
         },
-        "isOptional": false,
         "documentation": ""
       }
     ],
@@ -150,31 +150,31 @@ exports[`generateASTForProject with multiple schemas 1`] = `
     "fields": [
       {
         "name": "page",
+        "isOptional": false,
         "type": {
           "name": "string",
           "zodType": "z.string()"
         },
-        "isOptional": false,
         "documentation": "",
         "defaultValue": "'index'"
       },
       {
         "name": "loggedIn",
+        "isOptional": false,
         "type": {
           "name": "boolean",
           "zodType": "z.boolean()"
         },
-        "isOptional": false,
         "documentation": "",
         "defaultValue": "false"
       },
       {
         "name": "time",
+        "isOptional": false,
         "type": {
           "name": "Date",
           "zodType": "z.date()"
         },
-        "isOptional": false,
         "documentation": ""
       }
     ],
@@ -189,20 +189,20 @@ exports[`generateASTForProject with multiple schemas 1`] = `
     "fields": [
       {
         "name": "source_name",
+        "isOptional": false,
         "type": {
           "name": "string",
           "zodType": "z.string()"
         },
-        "isOptional": false,
         "documentation": ""
       },
       {
         "name": "source_id",
+        "isOptional": true,
         "type": {
           "name": "number",
           "zodType": "z.number().optional()"
         },
-        "isOptional": true,
         "documentation": ""
       }
     ],
@@ -217,88 +217,88 @@ exports[`generateASTForProject with multiple schemas 1`] = `
     "fields": [
       {
         "name": "isOriginal",
+        "isOptional": false,
         "type": {
           "name": "boolean",
           "zodType": "z.boolean()"
         },
-        "isOptional": false,
         "documentation": "is the source original or a proxy."
       },
       {
         "name": "id",
+        "isOptional": false,
         "type": {
           "name": "string",
           "syfttype": "UUID",
           "zodType": "z.string().uuid()"
         },
-        "isOptional": false,
         "documentation": "id of the source."
       },
       {
         "name": "type",
+        "isOptional": false,
         "type": {
           "name": "SourceType",
           "typeFields": [
             {
               "name": "source_name",
+              "isOptional": false,
               "type": {
                 "name": "string",
                 "zodType": "z.string()"
-              },
-              "isOptional": false
+              }
             },
             {
               "name": "source_id",
+              "isOptional": true,
               "type": {
                 "name": "number",
-                "zodType": "z.number()"
-              },
-              "isOptional": true
+                "zodType": "z.number().optional()"
+              }
             }
           ],
-          "zodType": "z.object({\\n    \\tsource_name: z.string(),\\n\\tsource_id: z.number()\\n  })"
+          "zodType": "z.object({\\n    \\tsource_name: z.string(),\\n\\tsource_id: z.number().optional()\\n  })"
         },
-        "isOptional": false,
         "documentation": "Source type."
       },
       {
         "name": "eventType",
+        "isOptional": true,
         "type": {
           "name": "EventType",
           "typeFields": [
             {
               "name": "name",
+              "isOptional": false,
               "type": {
                 "name": "string",
                 "zodType": "z.string()"
-              },
-              "isOptional": false
+              }
             },
             {
               "name": "id",
+              "isOptional": true,
               "type": {
                 "name": "number",
-                "zodType": "z.number()"
-              },
-              "isOptional": true
+                "zodType": "z.number().optional()"
+              }
             },
             {
               "name": "test_field",
+              "isOptional": true,
               "type": {
                 "name": "string",
-                "zodType": "z.string()"
-              },
-              "isOptional": true
+                "zodType": "z.string().optional()"
+              }
             }
           ],
-          "zodType": "z.object({\\n    \\tname: z.string(),\\n\\tid: z.number(),\\n\\ttest_field: z.string()\\n  }).optional()"
+          "zodType": "z.object({\\n    \\tname: z.string(),\\n\\tid: z.number().optional(),\\n\\ttest_field: z.string().optional()\\n  }).optional()"
         },
-        "isOptional": true,
         "documentation": ""
       }
     ],
     "traits": [],
-    "zodType": "z.object({\\n    \\tisOriginal: z.boolean(),\\n\\tid: z.string().uuid(),\\n\\ttype: z.object({\\n    \\tsource_name: z.string(),\\n\\tsource_id: z.number()\\n  }),\\n\\teventType: z.object({\\n    \\tname: z.string(),\\n\\tid: z.number(),\\n\\ttest_field: z.string()\\n  }).optional()\\n  })"
+    "zodType": "z.object({\\n    \\tisOriginal: z.boolean(),\\n\\tid: z.string().uuid(),\\n\\ttype: z.object({\\n    \\tsource_name: z.string(),\\n\\tsource_id: z.number().optional()\\n  }),\\n\\teventType: z.object({\\n    \\tname: z.string(),\\n\\tid: z.number().optional(),\\n\\ttest_field: z.string().optional()\\n  }).optional()\\n  })"
   },
   {
     "name": "SourceUpdated",
@@ -308,88 +308,88 @@ exports[`generateASTForProject with multiple schemas 1`] = `
     "fields": [
       {
         "name": "isOriginal",
+        "isOptional": false,
         "type": {
           "name": "boolean",
           "zodType": "z.boolean()"
         },
-        "isOptional": false,
         "documentation": "is the source original or a proxy."
       },
       {
         "name": "id",
+        "isOptional": false,
         "type": {
           "name": "string",
           "syfttype": "UUID",
           "zodType": "z.string().uuid()"
         },
-        "isOptional": false,
         "documentation": "id of the source."
       },
       {
         "name": "type",
+        "isOptional": false,
         "type": {
           "name": "SourceType",
           "typeFields": [
             {
               "name": "source_name",
+              "isOptional": false,
               "type": {
                 "name": "string",
                 "zodType": "z.string()"
-              },
-              "isOptional": false
+              }
             },
             {
               "name": "source_id",
+              "isOptional": true,
               "type": {
                 "name": "number",
-                "zodType": "z.number()"
-              },
-              "isOptional": true
+                "zodType": "z.number().optional()"
+              }
             }
           ],
-          "zodType": "z.object({\\n    \\tsource_name: z.string(),\\n\\tsource_id: z.number()\\n  })"
+          "zodType": "z.object({\\n    \\tsource_name: z.string(),\\n\\tsource_id: z.number().optional()\\n  })"
         },
-        "isOptional": false,
         "documentation": "Source type."
       },
       {
         "name": "eventType",
+        "isOptional": true,
         "type": {
           "name": "EventType",
           "typeFields": [
             {
               "name": "name",
+              "isOptional": false,
               "type": {
                 "name": "string",
                 "zodType": "z.string()"
-              },
-              "isOptional": false
+              }
             },
             {
               "name": "id",
+              "isOptional": true,
               "type": {
                 "name": "number",
-                "zodType": "z.number()"
-              },
-              "isOptional": true
+                "zodType": "z.number().optional()"
+              }
             },
             {
               "name": "test_field",
+              "isOptional": true,
               "type": {
                 "name": "string",
-                "zodType": "z.string()"
-              },
-              "isOptional": true
+                "zodType": "z.string().optional()"
+              }
             }
           ],
-          "zodType": "z.object({\\n    \\tname: z.string(),\\n\\tid: z.number(),\\n\\ttest_field: z.string()\\n  }).optional()"
+          "zodType": "z.object({\\n    \\tname: z.string(),\\n\\tid: z.number().optional(),\\n\\ttest_field: z.string().optional()\\n  }).optional()"
         },
-        "isOptional": true,
         "documentation": ""
       }
     ],
     "traits": [],
-    "zodType": "z.object({\\n    \\tisOriginal: z.boolean(),\\n\\tid: z.string().uuid(),\\n\\ttype: z.object({\\n    \\tsource_name: z.string(),\\n\\tsource_id: z.number()\\n  }),\\n\\teventType: z.object({\\n    \\tname: z.string(),\\n\\tid: z.number(),\\n\\ttest_field: z.string()\\n  }).optional()\\n  })"
+    "zodType": "z.object({\\n    \\tisOriginal: z.boolean(),\\n\\tid: z.string().uuid(),\\n\\ttype: z.object({\\n    \\tsource_name: z.string(),\\n\\tsource_id: z.number().optional()\\n  }),\\n\\teventType: z.object({\\n    \\tname: z.string(),\\n\\tid: z.number().optional(),\\n\\ttest_field: z.string().optional()\\n  }).optional()\\n  })"
   },
   {
     "name": "NotifChannelAction",
@@ -399,57 +399,57 @@ exports[`generateASTForProject with multiple schemas 1`] = `
     "fields": [
       {
         "name": "name",
+        "isOptional": false,
         "type": {
           "name": "string",
           "zodType": "z.string()"
         },
-        "isOptional": false,
         "documentation": "Name of the channel, this is a unique global name.\\n@min 5"
       },
       {
         "name": "type",
+        "isOptional": false,
         "type": {
           "name": "ChannelType",
           "typeFields": [
             {
               "name": "channel_name",
+              "isOptional": false,
               "type": {
                 "name": "string",
                 "zodType": "z.string()"
-              },
-              "isOptional": false
+              }
             },
             {
               "name": "channel_type",
+              "isOptional": false,
               "type": {
                 "name": "string",
                 "zodType": "z.string()"
-              },
-              "isOptional": false
+              }
             }
           ],
           "zodType": "z.object({\\n    \\tchannel_name: z.string(),\\n\\tchannel_type: z.string()\\n  })"
         },
-        "isOptional": false,
         "documentation": ""
       },
       {
         "name": "webhook",
+        "isOptional": false,
         "type": {
           "name": "string",
           "syfttype": "Url",
           "zodType": "z.string().url()"
         },
-        "isOptional": false,
         "documentation": ""
       },
       {
         "name": "count",
+        "isOptional": false,
         "type": {
           "name": "number",
           "zodType": "z.number()"
         },
-        "isOptional": false,
         "documentation": "Number of notifications fired so far.\\n@min 0"
       }
     ],
@@ -464,57 +464,57 @@ exports[`generateASTForProject with multiple schemas 1`] = `
     "fields": [
       {
         "name": "name",
+        "isOptional": false,
         "type": {
           "name": "string",
           "zodType": "z.string()"
         },
-        "isOptional": false,
         "documentation": "Name of the channel, this is a unique global name.\\n@min 5"
       },
       {
         "name": "type",
+        "isOptional": false,
         "type": {
           "name": "ChannelType",
           "typeFields": [
             {
               "name": "channel_name",
+              "isOptional": false,
               "type": {
                 "name": "string",
                 "zodType": "z.string()"
-              },
-              "isOptional": false
+              }
             },
             {
               "name": "channel_type",
+              "isOptional": false,
               "type": {
                 "name": "string",
                 "zodType": "z.string()"
-              },
-              "isOptional": false
+              }
             }
           ],
           "zodType": "z.object({\\n    \\tchannel_name: z.string(),\\n\\tchannel_type: z.string()\\n  })"
         },
-        "isOptional": false,
         "documentation": ""
       },
       {
         "name": "webhook",
+        "isOptional": false,
         "type": {
           "name": "string",
           "syfttype": "Url",
           "zodType": "z.string().url()"
         },
-        "isOptional": false,
         "documentation": ""
       },
       {
         "name": "count",
+        "isOptional": false,
         "type": {
           "name": "number",
           "zodType": "z.number()"
         },
-        "isOptional": false,
         "documentation": "Number of notifications fired so far.\\n@min 0"
       }
     ],

--- a/packages/codehandler/tests/deserializer/ts_model.test.ts
+++ b/packages/codehandler/tests/deserializer/ts_model.test.ts
@@ -12,7 +12,6 @@ describe('generateASTForProject', () => {
 
   it('with multiple schemas', async () => {
     const ast = deserialize(['./tests/test_schema/multiple_events']);
-
     expect(ast).toBeDefined();
     expect(ast?.eventSchemas.length).toBe(8);
     expect(JSON.stringify(ast?.eventSchemas, null, 2)).toMatchSnapshot();

--- a/packages/codehandler/tests/deserializer/ts_model.test.ts
+++ b/packages/codehandler/tests/deserializer/ts_model.test.ts
@@ -12,6 +12,7 @@ describe('generateASTForProject', () => {
 
   it('with multiple schemas', async () => {
     const ast = deserialize(['./tests/test_schema/multiple_events']);
+
     expect(ast).toBeDefined();
     expect(ast?.eventSchemas.length).toBe(8);
     expect(JSON.stringify(ast?.eventSchemas, null, 2)).toMatchSnapshot();

--- a/packages/codehandler/tests/generators/ts_generator.test.ts
+++ b/packages/codehandler/tests/generators/ts_generator.test.ts
@@ -10,16 +10,17 @@ const TEST_FIELDS: Field[] = [
     type: {
       name: 'boolean',
       zodType: 'z.boolean()'
-    }
+    },
+    isOptional: false
   },
   {
     name: 'has_focus',
     type: {
       name: 'boolean',
-      zodType: 'z.boolean()',
-      isOptional: true
+      zodType: 'z.boolean()'
     },
-    defaultValue: 'false'
+    defaultValue: 'false',
+    isOptional: true
   }
 ];
 

--- a/packages/codehandler/tests/generators/ts_generator.test.ts
+++ b/packages/codehandler/tests/generators/ts_generator.test.ts
@@ -10,16 +10,15 @@ const TEST_FIELDS: Field[] = [
     type: {
       name: 'boolean',
       zodType: 'z.boolean()'
-    },
-    isOptional: false
+    }
   },
   {
     name: 'has_focus',
     type: {
       name: 'boolean',
-      zodType: 'z.boolean()'
+      zodType: 'z.boolean()',
+      isOptional: true
     },
-    isOptional: true,
     defaultValue: 'false'
   }
 ];

--- a/packages/codehandler/tests/test_project/index.ts
+++ b/packages/codehandler/tests/test_project/index.ts
@@ -1,0 +1,36 @@
+declare global {
+  interface Window {
+    amplitude: any;
+    gtag: any;
+  }
+}
+export function amplitudeTest(optionalField?: number): void {
+  window.amplitude.track('event-ampli-1', {
+    argOpt: optionalField,
+    arg2: false
+  });
+
+  window.amplitude.track({
+    eventName: 'event-ampli-2',
+    arg1: 1,
+    arg2: false
+  });
+
+  const path = 'wow';
+  window.amplitude.page('event-ampli-page', {
+    path,
+    arg2: false
+  });
+}
+
+export function gaTest(): void {
+  window.gtag('event', 'event-ga-1', {
+    arg1: 1,
+    arg2: false
+  });
+
+  window.gtag('set', 'user', {
+    userid: 1,
+    email: 'abc@acme.com'
+  });
+}

--- a/packages/codehandler/tests/test_project/index.ts
+++ b/packages/codehandler/tests/test_project/index.ts
@@ -16,6 +16,15 @@ export function amplitudeTest(optionalField?: number): void {
     arg2: false
   });
 
+  // below is a duplicate track call for "event-ampli-2", with different properties.
+  // our analyzer merges them.
+  window.amplitude.track({
+    eventName: 'event-ampli-2',
+    arg1: optionalField, // test merging isOptional
+    arg2: false,
+    arg3: 'wow' // test merging new args
+  });
+
   const path = 'wow';
   window.amplitude.page('event-ampli-page', {
     path,


### PR DESCRIPTION
## Background
We'd like to give a simple drop-in solution to analyze existing codebases and extract existing event schemas out of it.

## Purpose
- Easier onboarding.
- A drop-in monitoring solution on product analytics. Data / PM team can monitor on changes to events during build time.

