### PR TITLE
remove monitoring logic from syft client and add a custom plugin

### DIFF
--- a/packages/client/src/batcher.ts
+++ b/packages/client/src/batcher.ts
@@ -1,29 +1,23 @@
 import { TestingPlugin } from '.';
-import type { SyftEvent } from '.';
-import { extractSchema } from './monitor/parser';
-import type { ApiEvent } from './monitor/types';
-import Monitor from './monitor';
+import type { IEventDispatcher, SyftEvent } from '.';
 import {
-  type IEventDispatcher,
-  type FullConfig,
-  type IConfigStore,
-  type IMonitor,
-  SyftEventTrackStatus,
-  SyftEventValidStatus,
   SyftEventInstrumentStatus,
+  type FullConfig,
   type IReflector,
-  type ISyftPlugin
+  type ISyftPlugin,
+  SyftEventTrackStatus,
+  SyftEventValidStatus
 } from './types';
 import { convertCase } from './utils';
 import { PluginLoader } from './PluginLoader';
 
-/* eslint-disable @typescript-eslint/no-var-requires */
-let EnvClasses;
+let DispatcherModule;
 if (typeof window !== 'undefined') {
-  EnvClasses = require('./browser');
+  DispatcherModule = require('./browser/dispatcher');
 } else {
-  EnvClasses = require('./node');
+  DispatcherModule = require('./node/dispatcher');
 }
+const DispatcherClass = DispatcherModule.default;
 
 export default class Batcher {
   private readonly config: FullConfig;
@@ -31,20 +25,12 @@ export default class Batcher {
   readonly pluginLoader: PluginLoader;
   private plugins: ISyftPlugin[] = [];
   private pendingEvents: SyftEvent[] = []; // hold events in the queue until all plugins are loaded.
-
-  private monitorEvents: ApiEvent[] = [];
-  private flushAttemptTimestamp: number; // last flush attempt timestamp
-
-  private readonly monitor: IMonitor;
-  private readonly configStore: IConfigStore;
   private readonly dispatcher: IEventDispatcher;
 
   constructor(config: FullConfig) {
     this.config = config;
-    this.monitor = new Monitor(config, new EnvClasses.JsonUploader());
-    this.configStore = new EnvClasses.ConfigStore();
-    this.dispatcher = new EnvClasses.EventDispatcher();
     this.pluginLoader = new PluginLoader(config.plugins);
+    this.dispatcher = new DispatcherClass();
   }
 
   // TODO move plugin loader to caller level.
@@ -111,31 +97,10 @@ export default class Batcher {
         return false;
       }
     }
-    const { syft, ...eventProperties } = event;
-    this._reflectEvent(
-      syft.eventName,
-      eventProperties,
-      SyftEventTrackStatus.TRACKED,
-      syft.isValid ? SyftEventValidStatus.VALID : SyftEventValidStatus.NOT_VALID
-    );
     return true;
   }
 
   reflectEvent(name: string, props: Record<string, any>): void {
-    this._reflectEvent(
-      name,
-      props,
-      SyftEventTrackStatus.NOT_TRACKED,
-      SyftEventValidStatus.UNKNOWN
-    );
-  }
-
-  _reflectEvent(
-    name: string,
-    props: Record<string, any>,
-    tracked: SyftEventTrackStatus,
-    valid: SyftEventValidStatus
-  ): void {
     if (!this.config.monitor.disabled) {
       this.dispatcher.dispatch({
         type: 'syft-event',
@@ -144,80 +109,17 @@ export default class Batcher {
           props: props ?? {},
           syft_status: {
             instrument: SyftEventInstrumentStatus.INSTRUMENTED,
-            track: SyftEventTrackStatus[tracked],
-            valid: SyftEventValidStatus[valid]
+            track: SyftEventTrackStatus.NOT_TRACKED,
+            valid: SyftEventValidStatus.UNKNOWN
           }
         }
       });
     }
-
-    if (
-      this.config.monitor.remote == null ||
-      this.config.monitor.remote === ''
-    ) {
-      return;
-    }
-
-    const fields = extractSchema(props);
-    this.monitorEvents.push({
-      name,
-      eventType: 'event',
-      fields
-    });
-    if (this.config.verbose) {
-      console.debug(`Event ${name} has schema ${JSON.stringify(fields)}`);
-    }
-    this.uploadIfRequired();
   }
 
   flush(): void {
-    this.upload();
-  }
-
-  private uploadIfRequired(): void {
-    const batchSize = this.monitorEvents.length;
-    const now = Date.now();
-    const timeSinceLastFlushAttempt = now - this.flushAttemptTimestamp;
-
-    const sendBySize = batchSize % this.config.monitor.batchSize === 0;
-    const sendByTime =
-      timeSinceLastFlushAttempt >= this.config.monitor.batchFlushSeconds * 1000;
-
-    if (sendBySize || sendByTime) {
-      this.upload();
+    for (const plugin of this.plugins) {
+      if (plugin.requestFlush != null) plugin.requestFlush();
     }
-  }
-
-  private upload(): void {
-    const now = Date.now();
-    const sendingEvents = this.monitorEvents;
-    this.flushAttemptTimestamp = now;
-    this.monitorEvents = [];
-
-    const stopUntilTimestamp = this.configStore.get('stopUntilTimestamp');
-    if (stopUntilTimestamp != null && now < stopUntilTimestamp) {
-      console.info(`Uploads are diasbled till ${stopUntilTimestamp as number}`);
-      return;
-    }
-
-    this.monitor.monitor(sendingEvents, (resp) => {
-      if (resp.stopUntil != null) {
-        this.configStore.set(
-          'stopUntilTimestamp',
-          this.flushAttemptTimestamp + resp.stopUntil
-        );
-      }
-
-      if (resp.error != null) {
-        this.monitorEvents = this.monitorEvents.concat(sendingEvents);
-        if (this.config.verbose) {
-          console.warn('batch sending failed!', resp.error.message);
-        }
-      }
-    });
-  }
-
-  getMonitorQueue(): ApiEvent[] {
-    return this.monitorEvents;
   }
 }

--- a/packages/client/src/plugins/Custom.ts
+++ b/packages/client/src/plugins/Custom.ts
@@ -1,0 +1,62 @@
+import { type SyftEvent, type ISyftPlugin } from '../types';
+
+export class SyftCustomPlugin implements ISyftPlugin {
+  id = 'SyftCustomPlugin';
+  events: SyftEvent[] = [];
+
+  upload: (events: SyftEvent[]) => Promise<any>;
+  uploadInterval: number;
+  batchSize: number;
+
+  flushAttemptTimestamp: number; // last flush attempt timestamp
+  isUploading: boolean = false;
+
+  constructor(
+    upload: (events: SyftEvent[]) => Promise<any>,
+    batchSize: number = 10,
+    uploadInterval: number = 1000
+  ) {
+    this.upload = upload;
+    this.batchSize = batchSize;
+    this.uploadInterval = uploadInterval;
+  }
+
+  isLoaded(): boolean {
+    return true;
+  }
+
+  init(): void {}
+
+  logEvent(event: SyftEvent): boolean {
+    this.events.push(event);
+    this.flushIfRequired();
+    return true;
+  }
+
+  flushIfRequired(): void {
+    if (this.isUploading) return;
+    if (this.events.length >= this.batchSize) {
+      this.__flush();
+    }
+    const now = Date.now();
+    const timeSinceLastFlushAttempt = now - this.flushAttemptTimestamp;
+    if (timeSinceLastFlushAttempt >= this.uploadInterval) {
+      this.__flush();
+    }
+  }
+
+  __flush(): void {
+    const events = this.events.splice(0, this.events.length);
+    this.isUploading = true;
+    this.flushAttemptTimestamp = Date.now();
+    this.upload(events).finally(() => {
+      this.isUploading = false;
+    });
+  }
+
+  requestFlush(): void {
+    this.__flush();
+  }
+
+  resetUserProperties(): void {}
+}

--- a/packages/client/src/plugins/index.ts
+++ b/packages/client/src/plugins/index.ts
@@ -4,3 +4,4 @@ export * from './MixPanel';
 export * from './Heap';
 export * from './GA4';
 export * from './TestingPlugin';
+export * from './Custom';

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -150,6 +150,8 @@ export interface ISyftPlugin {
 
   /** Gets called when syft.resetUser() is called. */
   resetUserProperties: () => void;
+
+  requestFlush?: () => void;
 }
 
 export interface MonitorResponse {

--- a/packages/client/tests/batcher.test.ts
+++ b/packages/client/tests/batcher.test.ts
@@ -1,4 +1,4 @@
-import { type IReflector } from '../lib';
+import { type IReflector } from '../src/types';
 import Batcher from '../src/batcher';
 import {
   type ISyftPlugin,

--- a/packages/codehandler/src/analyzers/plugins/amplitude.ts
+++ b/packages/codehandler/src/analyzers/plugins/amplitude.ts
@@ -5,7 +5,7 @@ import { type Usage } from '..';
 
 export class AmplitudeAnalyser extends BaseAnalyser {
   isAMatch(expression: string): SyftEventType | undefined {
-    if (expression.endsWith('.track')) {
+    if (expression.endsWith('.track') || expression.endsWith('.logEvent')) {
       return SyftEventType.TRACK;
     }
     if (expression.endsWith('.page')) {

--- a/packages/codehandler/src/deserializer/ts_morph_utils.ts
+++ b/packages/codehandler/src/deserializer/ts_morph_utils.ts
@@ -12,8 +12,7 @@ import {
   type Field,
   type TypeSchema
 } from '@syftdata/common/lib/types';
-import { ANY_TYPE, getZodType, getZodTypeForSchema } from './zod_utils';
-import { type } from 'os';
+import { getZodType, getZodTypeForSchema } from './zod_utils';
 
 // const SyftypeModuleIndex = 'client/src/index".type.'
 const SyftypeIndex = 'type.';


### PR DESCRIPTION
- Reduce syft client package size by removing monitoring logic
- Add a Custom plugin to upload events to whereever we like. 