### PR TITLE
a user-friendly event-emitter yaml

### DIFF
--- a/packages/cli/src/codegen/generators/yaml_generator.ts
+++ b/packages/cli/src/codegen/generators/yaml_generator.ts
@@ -1,0 +1,69 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as yaml from 'js-yaml';
+import { type AST } from '@syftdata/common/lib/types';
+
+function changeType(value: any): any {
+  if (typeof value.name !== 'string') {
+    return value;
+  }
+  if (value.name === '__type') {
+    return {
+      ...value,
+      name: 'object'
+    };
+  } else if (value.isArray === true) {
+    return {
+      ...value,
+      name: 'array'
+    };
+  } else {
+    return value.name;
+  }
+}
+
+function replacer(key: string, value: any): any {
+  if (value != null && typeof value === 'object' && !Array.isArray(value)) {
+    const replacement = {};
+    Object.keys(value).forEach((k) => {
+      if (
+        k === 'syftConfig' ||
+        k === 'zodType' ||
+        k === 'eventType' ||
+        k === 'exported' ||
+        k === 'documentation' ||
+        k === 'isArray'
+      )
+        return;
+
+      if (k === 'isOptional' || k === 'isMany') {
+        if (value[k] == null || value[k] === false) return;
+      }
+
+      let key = k;
+      if (k === 'eventSchemas') key = 'events';
+      else if (k === 'dbSourceDetails') key = 'source';
+      else if (k === 'dbRelation') key = 'relation';
+      else if (k === 'typeFields') key = 'fields';
+
+      if (key === 'type') {
+        replacement[key] = changeType(value[k]);
+        return;
+      }
+      replacement[key] = value[k];
+    });
+    return replacement;
+  }
+  return value;
+}
+
+export function generate(ast: AST, destDir: string): void {
+  fs.mkdirSync(destDir, { recursive: true });
+  ast.eventSchemas = ast.eventSchemas.filter((schema) => {
+    return schema.exported === true;
+  });
+  const astYaml = yaml.dump(ast, {
+    replacer
+  });
+  fs.writeFileSync(path.join(destDir, 'schema.yaml'), astYaml);
+}

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -1,9 +1,8 @@
 import type * as yargs from 'yargs';
 import * as fs from 'fs';
-import * as path from 'path';
-import * as yaml from 'js-yaml';
 import { generate as generateTS } from '../codegen/generators/ts_generator';
 import { generate as generateDocs } from '../codegen/generators/doc_generator';
+import { generate as generateYaml } from '../codegen/generators/yaml_generator';
 import { generate as generateGo } from '../codegen/generators/go_generator';
 import { generate as generateDBT } from '../codegen/generators/dbt_generator';
 import { type ProviderConfig } from '../config/sink_configs';
@@ -121,18 +120,7 @@ async function innerHandler({
       const providerConfig = await getProviderConfig();
       generateDBT(ast, outDir ?? './dbt', providerConfig);
     } else if (type === 'yaml') {
-      ast.eventSchemas = ast.eventSchemas.filter((schema) => {
-        return schema.exported === true;
-      });
-      const astYaml = yaml.dump(ast, {
-        replacer: (key, value) => {
-          if (key === 'syftConfig' || key === 'zodType') {
-            return undefined;
-          }
-          return value;
-        }
-      });
-      fs.writeFileSync(path.join(outDir ?? './', 'schema.yaml'), astYaml);
+      generateYaml(ast, outDir ?? './');
     }
   }
   return ast;


### PR DESCRIPTION
- ignore all optional fields in the final output to reduce the verbosity
- rename internal names to user-friendly names.
